### PR TITLE
fix(docu): action version in demo was incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Buildah Action
-      uses: redhat-actions/buildah-build@v1
+      uses: redhat-actions/buildah-build@v2
       with:
         image: my-new-image
         tags: v1 ${{ github.sha }}
@@ -190,7 +190,7 @@ jobs:
     - run: mvn package
 
     - name: Build Image
-      uses: redhat-actions/buildah-build@v1
+      uses: redhat-actions/buildah-build@v2
       with:
         base-image: docker.io/fabric8/java-alpine-openjdk11-jre
         image: my-new-image


### PR DESCRIPTION
### Description

As of v2 of this action `tag` got renamed to `tags` and the later was already reflected in the readme demos.
However, the version of the action in the demos was still v1 which leads to confusion.
This PR fixes this by explicitly using v2 in the readme demos now :wink: 

### Changes

* bump action version in readme demos

### Issue

* #29 