### PR TITLE
Update README to point to podman-login action

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,16 @@ sudo podman run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ```
 
 ## Using private images
-If your build requires a private image, you have to `docker login` in a step before running this action.
+
+If your build requires a private image, use [**podman-login**](https://github.com/redhat-actions/podman-login) action in a step before running this action to authenticate to the container image registry.
 
 For example:
+
 ```yaml
 - name: Log in to Red Hat Registry
-  run: echo "${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}" | docker login registry.redhat.io -u "${{ secrets.REGISTRY_REDHAT_IO_USER }}" --password-stdin
+  uses: redhat-action/podman-login@v1
+  with:
+    registry: registry.redhat.io
+    username: ${{ secrets.REGISTRY_REDHAT_IO_USER }}
+    password: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
 ```

--- a/README.md
+++ b/README.md
@@ -152,8 +152,7 @@ sudo podman run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 ## Using private images
 
-If your build requires a private image, use [**podman-login**](https://github.com/redhat-actions/podman-login) action in a step before running this action to authenticate to the container image registry.
-
+If your build references a private image, run [**podman-login**](https://github.com/redhat-actions/podman-login) in a step before this action so you can pull the image.
 For example:
 
 ```yaml


### PR DESCRIPTION
Signed-off-by: divyansh42 <diagrawa@redhat.com>

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
Updated README to point to `podman-login` action instead of using login scripts
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change