### PR TITLE
Remove kubic repositories

### DIFF
--- a/.github/install_latest_buildah.sh
+++ b/.github/install_latest_buildah.sh
@@ -1,7 +1,3 @@
-# https://github.com/containers/buildah/blob/main/install.md
-. /etc/os-release
-sudo sh -c "echo 'deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/x${ID^}_${VERSION_ID}/ /' > /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list"
-wget -nv https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable/x${ID^}_${VERSION_ID}/Release.key -O Release.key
 sudo apt-key add - < Release.key
 sudo apt-get update -qq
 sudo apt-get -qq -y install buildah


### PR DESCRIPTION
Signed-off-by: divyansh42 <diagrawa@redhat.com>

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
As kubic repositories are no longer maintained, removing that from the testing workflows
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
Close: https://github.com/redhat-actions/buildah-build/issues/93
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [x] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [x] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
