### PR TITLE
Fix warning ARCH typo

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export function getArch(): string[] {
     if (arch && archs.length > 0) {
         core.warning(
             `Both "${Inputs.ARCH}" and "${Inputs.ARCHS}" inputs are set. `
-            + `Please use "${Inputs.ARCH}" if you want to provide multiple `
+            + `Please use "${Inputs.ARCHS}" if you want to provide multiple `
             + `ARCH else use ${Inputs.ARCH}". "${Inputs.ARCHS}" takes preference.`
         );
     }


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

The warning informing users when to use `arch` vs `archs` had a typo.

### Related Issue(s)

<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- src/utils.ts (warning message)
