### PR TITLE
Ignore TypeScript 7.x in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
- Adds an ignore rule to `.github/dependabot.yml` to prevent Dependabot from opening PRs for TypeScript 7.x
- The codebase was recently upgraded to TypeScript 5.9 in #156 and needs to stabilize before adopting a new major version
- Closes the existing Dependabot PR #160 (Bump typescript from 5.9.3 to 7.0.2)

## Test plan
- [ ] Verify Dependabot does not open new PRs for TypeScript >=7.0.0
- [ ] Verify Dependabot still opens PRs for other npm dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)