### PR TITLE
Remove broken install_latest_buildah.sh

### DIFF
--- a/.github/install_latest_buildah.sh
+++ b/.github/install_latest_buildah.sh
@@ -1,3 +1,0 @@
-sudo apt-key add - < Release.key
-sudo apt-get update -qq
-sudo apt-get -qq -y install buildah

--- a/.github/workflows/check-lowercase.yaml
+++ b/.github/workflows/check-lowercase.yaml
@@ -24,11 +24,6 @@ jobs:
   build:
     name: Build image using Buildah
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
-
     steps:
 
       # Checkout buildah action github repository
@@ -36,11 +31,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: "buildah-build"
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash buildah-build/.github/install_latest_buildah.sh
 
       - name: Create Dockerfile
         run: |

--- a/.github/workflows/containerfile_build.yml
+++ b/.github/workflows/containerfile_build.yml
@@ -23,11 +23,6 @@ jobs:
   build:
     name: Build image using Buildah
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
-
     steps:
 
       # Checkout buildah action github repository
@@ -35,11 +30,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: "buildah-build"
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash buildah-build/.github/install_latest_buildah.sh
 
       - name: Create Dockerfile
         run: |

--- a/.github/workflows/docker_metadata_action.yml
+++ b/.github/workflows/docker_metadata_action.yml
@@ -20,10 +20,6 @@ jobs:
   build-containerfile:
     name: Build image with Containerfile
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
 
     env:
       IMAGE_NAME: "hello-world"
@@ -49,11 +45,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash .github/install_latest_buildah.sh
 
       - name: Create Dockerfile
         run: |
@@ -99,10 +90,6 @@ jobs:
   build-scratch:
     name: Build image without Containerfile
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
 
     env:
       PROJECT_DIR: spring-petclinic
@@ -130,11 +117,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash .github/install_latest_buildah.sh
 
       # Checkout spring-petclinic github repository
       - name: Checkout spring-petclinic project

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -24,10 +24,6 @@ jobs:
     env:
       IMAGE_NAME: hello-world-multiarch
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
 
     steps:
 
@@ -36,11 +32,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: "buildah-build"
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash buildah-build/.github/install_latest_buildah.sh
 
       - name: Install qemu dependency
         run: |
@@ -92,10 +83,6 @@ jobs:
     env:
       IMAGE_NAME: hello-world-multiplatform
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
 
     steps:
 
@@ -104,11 +91,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: "buildah-build"
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash buildah-build/.github/install_latest_buildah.sh
 
       - name: Install qemu dependency
         run: |
@@ -159,10 +141,6 @@ jobs:
     env:
       IMAGE_NAME: spring-petclinic-multiarch
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
 
     steps:
 
@@ -171,11 +149,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: "buildah-build"
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash buildah-build/.github/install_latest_buildah.sh
 
       - name: Install qemu dependency
         run: |

--- a/.github/workflows/scratch_build.yml
+++ b/.github/workflows/scratch_build.yml
@@ -25,11 +25,6 @@ jobs:
   build:
     name: Build image using Buildah
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        install_latest: [ true, false ]
-
     steps:
 
       # Checkout buildah action github repository
@@ -37,11 +32,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: "buildah-build"
-
-      - name: Install latest buildah
-        if: matrix.install_latest
-        run: |
-          bash buildah-build/.github/install_latest_buildah.sh
 
       # Checkout spring-petclinic github repository
       - name: Checkout spring-petclinic project


### PR DESCRIPTION
## Summary
- Removes the broken `.github/install_latest_buildah.sh` script which referenced a non-existent `Release.key` file and used the deprecated `apt-key` command
- Removes the `install_latest` matrix dimension from all 5 workflows that used it, halving the number of CI jobs
- The ubuntu-24.04 runner already ships buildah 1.33.7, making the "install latest" test redundant

Fixes #120.

## Test plan
- [ ] Verify all CI workflows pass with the matrix removed
- [ ] Verify no remaining references to `install_latest_buildah.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)