### PR TITLE
Replace deprecated link checker and fix 429 failures

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -1,0 +1,6 @@
+{
+    "retryOn429": true,
+    "retryCount": 3,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [200, 206]
+}

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - '**.md'
   schedule:
-    - cron: '0 0 * * *'  # every day at midnight
+    - cron: '0 0 * * 1'  # every Monday at midnight
 
 permissions:
   contents: read
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: tcort/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true
+          config-file: .github/markdown-link-check-config.json


### PR DESCRIPTION
## Summary
- Replace archived `gaurav-nelson/github-action-markdown-link-check` with the maintained fork `tcort/github-action-markdown-link-check`
- Add retry-on-429 config to handle GitHub rate limiting that was causing false failures (this is why the Build badge shows "failing")
- Reduce scheduled check frequency from daily to weekly to avoid unnecessary rate limiting

## Context
The `gaurav-nelson/github-action-markdown-link-check` repo was archived in April 2026. The `buildah-config.1.md` link is valid but GitHub returns 429 responses to the checker bot, causing the Link checker workflow to fail on every run.

## Test plan
- [ ] Link checker workflow passes on this PR
- [ ] Verify the badge turns green on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)