### PR TITLE
Add workflow to rebuild bundle on Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-rebuild.yml
+++ b/.github/workflows/dependabot-rebuild.yml
@@ -1,0 +1,33 @@
+name: Rebuild bundle for Dependabot PRs
+
+on:
+  push:
+    branches:
+      - 'dependabot/**'
+    paths:
+      - 'package*.json'
+
+permissions:
+  contents: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      - run: npm ci
+
+      - run: npm run bundle
+
+      - name: Commit updated bundle
+        run: |
+          if git diff --quiet dist/; then
+            echo "Bundle is up to date"
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add dist/
+            git commit -m "Rebuild bundle after dependency update"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- Adds a workflow that automatically rebuilds `dist/index.js` when Dependabot pushes dependency updates
- Triggers on pushes to `dependabot/**` branches that change `package*.json`
- Prevents bundle-verifier CI failures on runtime dependency bumps

🤖 Generated with [Claude Code](https://claude.com/claude-code)